### PR TITLE
Cargo.toml: add `uudoc` as feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # hostname (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime fundu gethostid kqueue libselinux mangen memmap procfs uuhelp
+# spell-checker:ignore (libs) mangen procfs
 
 [package]
 name = "hostname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ build = "build.rs"
 
 [features]
 default = ["feat_common_core"]
+uudoc = []
 
 feat_common_core = [
   "hostname",


### PR DESCRIPTION
This PR adds `uudoc` as a feature to `Cargo.toml` to fix the warning "warning: invalid feature uudoc in required-features of target uudoc: uudoc is not present in [features] section". It also cleans up the "spell-checker:ignore" entries.