### PR TITLE
clippy: fix warnings introduced with Rust `1.89`

### DIFF
--- a/src/uu/hostname/src/net/unix.rs
+++ b/src/uu/hostname/src/net/unix.rs
@@ -240,7 +240,7 @@ impl InterfaceAddresses {
         }
     }
 
-    pub(crate) fn iter(&self) -> InterfaceAddressesIter {
+    pub(crate) fn iter(&self) -> InterfaceAddressesIter<'_> {
         InterfaceAddressesIter {
             _ia: self,
             ptr: Some(self.0),
@@ -304,7 +304,7 @@ impl AddressInfo {
         unsafe { self.0.as_ref() }
     }
 
-    pub(crate) fn iter(&self) -> AddressInfoIter {
+    pub(crate) fn iter(&self) -> AddressInfoIter<'_> {
         AddressInfoIter {
             _ia: self,
             ptr: Some(self.0),

--- a/src/uu/hostname/src/net/windows.rs
+++ b/src/uu/hostname/src/net/windows.rs
@@ -241,7 +241,7 @@ impl InterfaceAddresses {
         }
     }
 
-    pub(crate) fn iter(&self) -> InterfaceAddressesIter {
+    pub(crate) fn iter(&self) -> InterfaceAddressesIter<'_> {
         InterfaceAddressesIter {
             _ia: self,
             ptr: self.list,
@@ -337,7 +337,7 @@ impl AddressInfo {
         }
     }
 
-    pub(crate) fn iter(&self) -> AddressInfoIter {
+    pub(crate) fn iter(&self) -> AddressInfoIter<'_> {
         AddressInfoIter {
             _ia: self,
             ptr: Some(self.0),

--- a/src/uu/hostname/src/utils.rs
+++ b/src/uu/hostname/src/utils.rs
@@ -8,10 +8,10 @@ pub(crate) fn parse_host_name_file(path: &Path) -> UResult<Vec<u8>> {
 
     let first_byte = loop {
         let mut first_byte = [0_u8; 1];
-        if let Err(err) = file.read_exact(&mut first_byte) {
-            if err.kind() == std::io::ErrorKind::UnexpectedEof {
-                return Ok(Vec::default()); // Empty name.
-            }
+        if let Err(err) = file.read_exact(&mut first_byte)
+            && err.kind() == std::io::ErrorKind::UnexpectedEof
+        {
+            return Ok(Vec::default()); // Empty name.
         }
 
         match first_byte[0] {


### PR DESCRIPTION
This PR fixes a few clippy warnings introduced with Rust 1.89. Most are related to the [mismatched lifetime syntaxes lint](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint) described in the announcement and one to the [collapsible_if](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if) lint.