### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,19 +164,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "ctor-proc-macro 0.0.7",
- "dtor 0.3.0",
+ "ctor-proc-macro",
+ "dtor",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
- "ctor-proc-macro 0.0.13",
- "dtor 0.8.1",
  "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -184,12 +183,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "deranged"
@@ -235,16 +228,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
 dependencies = [
- "dtor-proc-macro 0.0.6",
-]
-
-[[package]]
-name = "dtor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
-dependencies = [
- "dtor-proc-macro 0.0.13",
+ "dtor-proc-macro",
 ]
 
 [[package]]
@@ -252,12 +236,6 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "equivalent"
@@ -386,7 +364,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.10.1",
+ "ctor 1.0.1",
  "libc",
  "phf",
  "phf_codegen",
@@ -507,9 +485,15 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "link-section"
-version = "0.2.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,22 +29,21 @@ feat_common_core = [
 ]
 
 [workspace.dependencies]
-uucore = "0.8.0"
-uutests = "0.8.0"
-ctor = "0.10.0"
 clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.3.0"
-regex = "1.10.4"
-libc = "0.2.154"
+ctor = "1.0.0"
 errno = "0.3"
+libc = "0.2.154"
 phf = "0.13.0"
 phf_codegen = "0.13.1"
-textwrap = { version = "0.16.1", features = ["terminal_size"] }
-xattr = "1.3.1"
-tempfile = "3.10.1"
 rand = { version = "0.10.0" }
+regex = "1.10.4"
+tempfile = "3.10.1"
+textwrap = { version = "0.16.1", features = ["terminal_size"] }
 utmpx = "0.2"
+uucore = "0.8.0"
+uutests = "0.8.0"
 windows-sys = { version = "0.61", features = [
   "Win32_Globalization",
   "Win32_Networking_WinSock",
@@ -53,28 +52,29 @@ windows-sys = { version = "0.61", features = [
   "Win32_System_SystemInformation",
   "Win32_Foundation",
 ] }
+xattr = "1.3.1"
 
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
-uucore = { workspace = true }
 phf = { workspace = true }
 textwrap = { workspace = true }
+uucore = { workspace = true }
 
 
 #
 hostname = { optional = true, version = "0.0.1", package = "uu_hostname", path = "src/uu/hostname" }
 
 [dev-dependencies]
+ctor = { workspace = true }
+libc = { workspace = true }
 pretty_assertions = "1.4.0"
+rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-libc = { workspace = true }
-rand = { workspace = true }
-uutests = { workspace = true }
-ctor = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
+uutests = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = { workspace = true }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_hostname");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.10.0` to <del>`1.0.0`</del>`1.0.1` and adapts `tests/tests.rs` to a change in `ctor`.